### PR TITLE
Shorter name for app ... 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Zap Social network app for Yunohost",
+    "name": "Zap",
     "id": "zap",
     "packaging_format": 1,
     "description": {


### PR DESCRIPTION
The name is too long and therefore looks weird in the app install list ... Also no need to say that it's for YunoHost é_è