### PR TITLE
Fix manifest app name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Zap Social network app for Yunohost",
+    "name": "Zap",
     "id": "zap",
     "packaging_format": 1,
     "description": {


### PR DESCRIPTION
The name of the app is quite long and leads to funky rendering on the app install list (in the webadmin) Also it's kinda obvious that it's a yunohost app :s  

So proposing just "Zap" instead, or possibly "Zap social network" (if that's really how people refer to it, e.g. people don't say "Mastodon social network" but just "Mastodon")