### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -101,7 +101,7 @@ cp -a "$tmpdir/cache" "${final_path}"
 cp -a "$tmpdir/store" "${final_path}"
 cp -a "$tmpdir/.htconfig.php" "${final_path}"
 cp -a "$tmpdir/php.log" "${final_path}"
-rm -Rf "$tmpdir"
+ynh_secure_remove "$tmpdir"
 chmod -R 777 $final_path/store
 mkdir $final_path/addon
 ynh_setup_source --dest_dir="$final_path/addon" --source_id="app_addons"


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 